### PR TITLE
Gemspec required_ruby_version 2.0+

### DIFF
--- a/tomlrb.gemspec
+++ b/tomlrb.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
This library uses the Ruby 2 feature keywords arguments. They're awesome.

(They're also not available on JRuby 1.7.)

This PR tells Rubygems about this compatibility level.
