### PR TITLE
Only ship the necessary libs in the gem artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: ruby
 before_install:
   - gem install bundler
 rvm:
-  - 2.2.1
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3

--- a/tomlrb.gemspec
+++ b/tomlrb.gemspec
@@ -14,9 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/fbernier/tomlrb"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files         = %w{LICENSE.txt} + Dir.glob("lib/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.0'
 end


### PR DESCRIPTION
There's no need to ship the test files in the gem artifact. This stips
the gem artifact down to just the files that are necessary to use the
lib and reduces on disk size of ruby installs.

Signed-off-by: Tim Smith <tsmith@chef.io>