### PR TITLE
Delegate #strftime to @time in local date and time objects

### DIFF
--- a/lib/tomlrb/local_date.rb
+++ b/lib/tomlrb/local_date.rb
@@ -4,7 +4,7 @@ module Tomlrb
   class LocalDate
     extend Forwardable
 
-    def_delegators :@time, :year, :month, :day
+    def_delegators :@time, :year, :month, :day, :strftime
 
     def initialize(year, month, day)
       @time = Time.new(year, month, day, 0, 0, 0, '-00:00')

--- a/lib/tomlrb/local_date_time.rb
+++ b/lib/tomlrb/local_date_time.rb
@@ -4,7 +4,7 @@ module Tomlrb
   class LocalDateTime
     extend Forwardable
 
-    def_delegators :@time, :year, :month, :day, :hour, :min, :sec, :usec, :nsec
+    def_delegators :@time, :year, :month, :day, :hour, :min, :sec, :usec, :nsec, :strftime
 
     def initialize(year, month, day, hour, min, sec) # rubocop:disable Metrics/ParameterLists
       @time = Time.new(year, month, day, hour, min, sec, '-00:00')

--- a/lib/tomlrb/local_time.rb
+++ b/lib/tomlrb/local_time.rb
@@ -4,7 +4,7 @@ module Tomlrb
   class LocalTime
     extend Forwardable
 
-    def_delegators :@time, :hour, :min, :sec, :usec, :nsec
+    def_delegators :@time, :hour, :min, :sec, :usec, :nsec, :strftime
 
     def initialize(hour, min, sec)
       @time = Time.new(0, 1, 1, hour, min, sec, '-00:00')


### PR DESCRIPTION
I need to give a "user" (developer) the result of a parsed TOML document, and in particular they often need to use the Date/Time #strftime method. Several methods are already delegated to @time, so I just added #strftime to create even more synergy between the built-ins and the custom TOML classes for dates and times.