### PR TITLE
Enable `symbolize_keys: true` for inline tables

### DIFF
--- a/lib/tomlrb/handler.rb
+++ b/lib/tomlrb/handler.rb
@@ -75,6 +75,7 @@ module Tomlrb
         current = merged_inline
         value = inline_array.pop
         inline_array.each_with_index do |inline_key, inline_index|
+          inline_key = inline_key.to_sym if @symbolize_keys
           last_key = inline_index == inline_array.size - 1
 
           if last_key

--- a/test/test_tomlrb.rb
+++ b/test/test_tomlrb.rb
@@ -43,6 +43,11 @@ describe Tomlrb::Parser do
       .must_equal({"table"=>[{"name"=>"name1", "visible"=>true}, {"name"=>"name2", "visible"=>false}]})
   end
 
+  it "symbolizes keys in a inline table if symbolize_keys: true" do
+    _( Tomlrb.parse("table={a=1, b=2}", symbolize_keys: true) )
+      .must_equal({:table=>{:a=>1, :b=>2}})
+  end
+
   it "raises an error when parsing a float with leading underscore" do
     _{ Tomlrb.parse('x = _1.0') }.must_raise(Tomlrb::ParseError)
   end


### PR DESCRIPTION
Keys in a inline table have not been symbolized even when `symbolize_keys: true` since 26ade435d64cef1ba0ecb8cd5eaf65afe811a104. The cause is that `Tomlrb::Handler#push_inline` does not check `@symbolize_keys` and does not symbolize keys even if `@symbolize_keys` is true. 

https://github.com/fbernier/tomlrb/blob/54bad185d1e826c7b267c331db89ed111bed77d0/lib/tomlrb/handler.rb#L71-L94

This commit fixes it and adds the test case.