### PR TITLE
Test on new rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.5, 2.6, 2.7, '3.0', '3.1', head, jruby, jruby-head, truffleruby]
+        ruby: [2.5, 2.6, 2.7, '3.0', '3.1', '3.2', '3.3', head, jruby, jruby-head, truffleruby]
     runs-on: ${{ matrix.os }}
     env:
       JRUBY_OPTS: -J-Xss16m


### PR DESCRIPTION
I'm expecting this to fail something like this:

```
/Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require': cannot load such file -- racc/parser.rb (LoadError)
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/tomlrb-2.0.3/lib/tomlrb/generated_parser.rb:7:in `<top (required)>'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/tomlrb-2.0.3/lib/tomlrb/parser.rb:1:in `<top (required)>'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /Users/blangfeld/.asdf/installs/ruby/3.3.0/lib/ruby/gems/3.3.0/gems/tomlrb-2.0.3/lib/tomlrb.rb:9:in `<top (required)>'
```