### PR TITLE
Load lib directory properly in benchmark

### DIFF
--- a/benchmarks/bench.rb
+++ b/benchmarks/bench.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require 'benchmark/ips'
-require_relative '../lib/tomlrb'
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+require 'tomlrb'
 begin
   require 'toml-rb'
 rescue LoadError
@@ -10,12 +12,11 @@ end
 data = File.read(File.join(__dir__, '../test/example-v0.4.0.toml'))
 
 Benchmark.ips do |x|
-
-  x.report("emancu/toml-rb") do
+  x.report('emancu/toml-rb') do
     TomlRB.parse(data)
   end
 
-  x.report("fbernier/tomlrb") do
+  x.report('fbernier/tomlrb') do
     Tomlrb.parse(data)
   end
 


### PR DESCRIPTION
bench.rb used `require_relative` to include the library, which caused problems when loading the lib directory.